### PR TITLE
Excludes triggering from CLC SSO Accounts.

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -220,7 +220,11 @@ class manager {
      * @return mixed a STATE variable from plugininfo
      */
     public static function get_status() {
-        global $SESSION;
+        global $SESSION, $USER;
+        
+        if ($USER->auth == 'clcadmin') {
+            self::set_pass_state();
+        }
 
         // Check for any instant fail states.
         $factors = \tool_mfa\plugininfo\factor::get_active_user_factor_types();
@@ -229,7 +233,6 @@ class manager {
                 return \tool_mfa\plugininfo\factor::STATE_FAIL;
             }
         }
-
         $passcondition = ((isset($SESSION->tool_mfa_authenticated) && $SESSION->tool_mfa_authenticated) ||
             self::passed_enough_factors());
 


### PR DESCRIPTION
These accounts already have MFA globally and do not require them on each instance.